### PR TITLE
Fix header link

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -57,7 +57,7 @@ const Header: React.FC = () => {
               <Link
                 to={pathName}
                 className={cn('text-textGray hover:text-textWhite', {
-                  'text-textWhite': location.pathname === pathName,
+                  'text-textWhite': location.pathname.includes(pathName),
                 })}
               >
                 {name}


### PR DESCRIPTION
When you go to the product page, the color of the categories is leave